### PR TITLE
Minor fixes to package.json for npmjs.org publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "ngDexie",
+    "name": "ngdexie",
     "version": "0.0.17",
     "description": "Angularjs wrapper around Dexie.js an IndexedDB handler",
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -18,11 +18,7 @@
         "type": "git",
         "url": "https://github.com/FlussoBV/NgDexie.git"
     },
-    "licenses": [
-        {
-            "type": "APACHE"
-        }
-    ],
+    "license" : "See license in LICENSE",
     "devDependencies": {
         "grunt": "~0.4.1",
         "grunt-contrib-concat": "~0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "ngdexie",
+    "name": "ng-dexie",
     "version": "0.0.17",
     "description": "Angularjs wrapper around Dexie.js an IndexedDB handler",
     "keywords": [


### PR DESCRIPTION
I just fixed minor errors to be able to publish the package into npmjs.org. 
It goes live here: [https://www.npmjs.com/package/ng-dexie](https://www.npmjs.com/package/ng-dexie)
I don't know if someone other than me can publish further version...
